### PR TITLE
Set a metadata only if it is present in the response from self.pcloud.listfolder

### DIFF
--- a/src/pcloud/pcloudfs.py
+++ b/src/pcloud/pcloudfs.py
@@ -108,13 +108,14 @@ class PCloudFS(FS):
             parent_path = parent_path if parent_path else '/'
         folder_list = self.pcloud.listfolder(path=parent_path)
         metadata = None
-        if _path == '/':
-            metadata = folder_list['metadata']
-        else:
-            for item in folder_list['metadata']['contents']:
-                if item['path'] == _path:
-                    metadata = item
-                    break
+        if 'metadata' in folder_list:
+            if _path == '/':
+                metadata = folder_list['metadata']
+            else:
+                for item in folder_list['metadata']['contents']:
+                    if item['path'] == _path:
+                        metadata = item
+                        break
         if metadata is None:
             raise errors.ResourceNotFound(path=path)
         return self._info_from_metadata(metadata, namespaces)


### PR DESCRIPTION
This Pull Request is to fix #10 
_folder_list_ dictionary might not contain a _metadata_ key, for example:

```
{'result': 2005, 'error': 'Directory does not exist.'}
```
