### PR TITLE
If a directory exists, raise errors.DirectoryExists as requested by fs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 1.0a6 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix error while using makedirs from PyFilesystem with recreate=True
+  [blasterspike]
 
 1.0a5 (2018-10-22)
 ------------------

--- a/src/pcloud/pcloudfs.py
+++ b/src/pcloud/pcloudfs.py
@@ -137,10 +137,13 @@ class PCloudFS(FS):
         self.check()
         result = self.pcloud.createfolder(path=path)
         if result['result'] != 0:
-            raise errors.CreateFailed(
-                'Create of directory "{0}" failed with "{1}"'.format(
-                    path, result['error'])
-            )
+            if result['result'] == 2004:
+                raise errors.DirectoryExists('Directory "{0}" already exists')
+            else:
+                raise errors.CreateFailed(
+                    'Create of directory "{0}" failed with "{1}"'.format(
+                        path, result['error'])
+                )
         else:  # everything is OK
             return self.opendir(path)
 

--- a/src/pcloud/pcloudfs.py
+++ b/src/pcloud/pcloudfs.py
@@ -136,14 +136,13 @@ class PCloudFS(FS):
     def makedir(self, path, permissions=None, recreate=False):
         self.check()
         result = self.pcloud.createfolder(path=path)
-        if result['result'] != 0:
-            if result['result'] == 2004:
-                raise errors.DirectoryExists('Directory "{0}" already exists')
-            else:
-                raise errors.CreateFailed(
-                    'Create of directory "{0}" failed with "{1}"'.format(
-                        path, result['error'])
-                )
+        if result['result'] == 2004:
+            raise errors.DirectoryExists('Directory "{0}" already exists')
+        elif result['result'] != 0:
+            raise errors.CreateFailed(
+                'Create of directory "{0}" failed with "{1}"'.format(
+                    path, result['error'])
+            )
         else:  # everything is OK
             return self.opendir(path)
 


### PR DESCRIPTION
If you run this code and all the directories `/backup/second_level/third_level` that you are trying to create already exists

```
import fs
from pcloud import PyCloud
import urllib.parse

username = urllib.parse.quote_plus('my_username')
password = urllib.parse.quote_plus('my_password')

with fs.opener.open_fs('pcloud://{0}:{1}@/'.format(username, password)) as pcloud_fs:
    pcloud_fs.makedirs(path='/backup/second_level/third_level', recreate=True)
```

you get the error

```
Traceback (most recent call last):
  File "pycloud_makedirs.py", line 9, in <module>
    result = pcloud_fs.makedirs(path='/backup/second_level/third_level', recreate=True)
  File "/usr/local/lib/python3.6/site-packages/fs/base.py", line 1035, in makedirs
    self.makedir(path)
  File "/usr/local/lib/python3.6/site-packages/pcloud/pcloudfs.py", line 142, in makedir
    path, result['error'])
fs.errors.CreateFailed: Create of directory "/backup/second_level/third_level" failed with "File or folder already exists."
```
regardless of the `recreate=True`.
When you call _makedirs_, PyFilesystem2 is expecting an `errors.DirectoryExists` in case the directory we want to create already exists:
https://github.com/PyFilesystem/pyfilesystem2/blob/v2.1.2/fs/base.py#L1036
With this pull request I'm raising `errors.DirectoryExists` in case I get a 2004 from pCloud
https://docs.pcloud.com/methods/folder/createfolder.html

```
{'result': 2004, 'error': 'File or folder already exists.'}
```

so that if I have a `recreate=True` I don't get back any error.