### PR TITLE
Added missing variable to format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 1.0a9 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Missing variable in output in case a directory already exists
+  [blasterspike]
 
 1.0a8 (2020-02-21)
 ------------------

--- a/src/pcloud/pcloudfs.py
+++ b/src/pcloud/pcloudfs.py
@@ -142,7 +142,8 @@ class PCloudFS(FS):
         self.check()
         result = self.pcloud.createfolder(path=path)
         if result["result"] == 2004:
-            raise errors.DirectoryExists('Directory "{0}" already exists')
+            raise errors.DirectoryExists(
+                'Directory "{0}" already exists'.format(path))
         elif result["result"] != 0:
             raise errors.CreateFailed(
                 'Create of directory "{0}" failed with "{1}"'.format(


### PR DESCRIPTION
This is to add a missing variable in the format of the raise output in case a directory already exists.
I introduced this error with this PR:
https://github.com/tomgross/pycloud/pull/13/files#diff-db715ce2458177ae7b258a6c9525ac27R140