### PR TITLE
Updated README and makedir function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 ------------------
 
 - Missing variable in output in case a directory already exists
+- Changed errors raised for makedirs
+- Do not raise an errors.DirectoryExists when recreate = True
+- Added examples to README
   [blasterspike]
 
 1.0a8 (2020-02-21)

--- a/README.rst
+++ b/README.rst
@@ -28,12 +28,6 @@ Usage of API
  >>> pc = PyCloud('email@example.com', 'SecretPassword')
  >>> pc.listfolder(folderid=0)
 
-Usage of PyFilesystem with opener
-
- >>> from fs import opener
- >>> opener.open_fs('pcloud://email%40example.com:SecretPassword@/')
- <pCloudFS>
-
 Uploading files
 
 a) from filenames:
@@ -50,6 +44,31 @@ b) from data:
   >>> img.save(bio, format='jpeg')
   >>> pc.uploadfile(data=bio.getvalue(), filename="image.jpg", path='/path-to-pcloud-dir')
 
+Usage of PyFilesystem with opener
+
+ >>> from fs import opener
+ >>> opener.open_fs('pcloud://email%40example.com:SecretPassword@/')
+ <pCloudFS>
+
+Copying files from Linux to pCloud using PyFilesystem
+
+  >>> from fs import opener, copy
+  >>> with opener.open_fs('pcloud://email%40example.com:SecretPassword@/') as pcloud_fs:
+  >>>    with opener.open_fs('/opt/data_to_copy') as linux_fs:
+  >>>        copy.copy_file(src_fs=linux_fs,
+  >>>                       src_path='database.sqlite3',
+  >>>                       dst_fs=pcloud_fs,
+  >>>                       dst_path='/backup/server/database.sqlite3')
+
+Copy directory from Linux to pCloud using PyFilesystem
+
+  >>> from fs import opener, copy
+  >>> with opener.open_fs('pcloud://email%40example.com:SecretPassword@/') as pcloud_fs:
+  >>>    with opener.open_fs('/opt/data_to_copy') as linux_fs:
+  >>>        copy.copy_dir(src_fs=linux_fs,
+  >>>                      src_path='database/',
+  >>>                      dst_fs=pcloud_fs,
+  >>>                      dst_path='/backup/database/')
 
 Documentation
 -------------

--- a/src/pcloud/pcloudfs.py
+++ b/src/pcloud/pcloudfs.py
@@ -142,14 +142,15 @@ class PCloudFS(FS):
         self.check()
         result = self.pcloud.createfolder(path=path)
         if result["result"] == 2004:
-            raise errors.DirectoryExists(
-                'Directory "{0}" already exists'.format(path))
+            if recreate:
+                # If the directory already exists and recreate = True
+                # we don't want to raise an error
+                pass
+            else:
+                raise errors.DirectoryExists(path)
         elif result["result"] != 0:
-            raise errors.CreateFailed(
-                'Create of directory "{0}" failed with "{1}"'.format(
-                    path, result["error"]
-                )
-            )
+            raise errors.OperationFailed(path=path,
+                                         msg='Create of directory failed with {0}'.format(result["error"]))
         else:  # everything is OK
             return self.opendir(path)
 


### PR DESCRIPTION
# errors raised

`errors.DirectoryExists` expects a path
https://github.com/PyFilesystem/pyfilesystem2/blob/v2.4.11/fs/errors.py#L313
https://docs.pyfilesystem.org/en/latest/reference/errors.html#fs.errors.DestinationExists


`errors.CreateFailed` is only for when the filesystem can't be created
https://docs.pyfilesystem.org/en/latest/reference/errors.html#fs.errors.CreateFailed
I think that OperationFailed is more indicated
https://docs.pyfilesystem.org/en/latest/reference/errors.html#fs.errors.OperationFailed

# pass on recreate = True

If `recreate = True`, do not raise an error on `makedir` as the directory has already been created.

I spotted this error while running an `fs.copy.copy_dir`, to copy directories between filesystems.
Sometimes the pCloud API are not fast enough in returning the directory that has just been created.
I have changed the log.debug to a print
https://github.com/tomgross/pycloud/blob/31d9676446de3e417396e296dd4a95441983173e/src/pcloud/api.py#L55-L59
and sometimes you might get the following

```
Doing request to %s%s https://api.pcloud.com/ createfolder
Params: %s {'auth': '***', 'path': '/backup/automatic/2020-04-27/opt/data/config/log/php'}
Doing request to %s%s https://api.pcloud.com/ listfolder
Params: %s {'auth': '***', 'path': '/backup/automatic/2020-04-27/opt/data/config/log'}
[...]
  File "/usr/local/lib/python3.7/dist-packages/fs/copy.py", line 299, in copy_dir
    _dst_fs.makedir(info.make_path(copy_path), recreate=True)
  File "/usr/local/lib/python3.7/dist-packages/pcloud/pcloudfs.py", line 154, in makedir
    return self.opendir(path)
  File "/usr/local/lib/python3.7/dist-packages/fs/base.py", line 1220, in opendir
    if not self.getbasic(path).is_dir:
  File "/usr/local/lib/python3.7/dist-packages/fs/base.py", line 1539, in getbasic
    return self.getinfo(path, namespaces=["basic"])
  File "/usr/local/lib/python3.7/dist-packages/pcloud/pcloudfs.py", line 125, in getinfo
    raise errors.ResourceNotFound(path=path)
```

This is because `makedir` first creates the folder
https://github.com/tomgross/pycloud/blob/31d9676446de3e417396e296dd4a95441983173e/src/pcloud/pcloudfs.py#L143
and returns an `opendir`
https://github.com/tomgross/pycloud/blob/31d9676446de3e417396e296dd4a95441983173e/src/pcloud/pcloudfs.py#L154
but it wasn't able to find the folder just created, thus raising an `errors.ResourceNotFound`.

In [this Pull Request](https://github.com/tomgross/pycloud/pull/13), it was sufficient to raise an `error.DirectoryExists` because `makedirs` in pyfilesystem was taking care of the `recreate` parameter
https://github.com/PyFilesystem/pyfilesystem2/blob/v2.4.11/fs/base.py#L1078
but in `copy_dir` this doesn't happen
https://github.com/PyFilesystem/pyfilesystem2/blob/v2.4.11/fs/copy.py#L292
so it needs to be handled in here.

# README

Added examples on how to copy a file and a directory using pyfilesystem2.