### PR TITLE
Add response details to AuthenticationError

### DIFF
--- a/src/pcloud/api.py
+++ b/src/pcloud/api.py
@@ -79,7 +79,7 @@ class PyCloud(object):
         }
         resp = self._do_request("userinfo", authenticate=False, **params)
         if "auth" not in resp:
-            raise (AuthenticationError)
+            raise AuthenticationError(resp)
         return resp["auth"]
 
     # Folders


### PR DESCRIPTION
Add response details to AuthenticationError during get_auth_token() so that AuthenticationError is a bit more descriptive on why the authentication failed.

There are more reasons authentication failed than using a wrong password, for example when 2FA is required or when the rate limited has been reached.

Examples:
```python
{
    'result': 2000,
    'error': 'Log in failed.'
}
```
```python
{
    'result': 2297,
    'error': 'Two factor authentication required.'
}
```

Documented errors can be found on the [pCloud API docs page](https://docs.pcloud.com/methods/general/userinfo.html).