### PR TITLE
Upload file with OAuth athentication

### DIFF
--- a/src/pcloud/api.py
+++ b/src/pcloud/api.py
@@ -227,7 +227,10 @@ class PyCloud(object):
 
     # File
     def _upload(self, method, files, **kwargs):
-        kwargs["auth"] = self.auth_token
+        if self.auth_token:  # Password authentication
+            kwargs["auth"] = self.auth_token
+        elif self.access_token:  # OAuth2 authentication
+            kwargs["access_token"] = self.access_token
         kwargs.pop("fd", None)
         fields = list(kwargs.items())
         fields.extend(files)


### PR DESCRIPTION
Pull request related to issue https://github.com/tomgross/pycloud/issues/55. Now you can upload files also via OAuth 2.0 authentication.